### PR TITLE
Fixing wrong assert firing since NDEBUG was not defined.

### DIFF
--- a/makefile
+++ b/makefile
@@ -8,6 +8,7 @@ dist_clean:: clean
 
 
 EMMC_OPTIM_FLAGS=\
+-D NDEBUG \
 -O3 \
 -s DISABLE_EXCEPTION_CATCHING=0
 

--- a/src/mcts/node.cc
+++ b/src/mcts/node.cc
@@ -192,7 +192,6 @@ EdgeList::EdgeList(MoveList moves)
 /////////////////////////////////////////////////////////////////////////
 
 Node* Node::CreateSingleChildNode(Move move) {
-  assert(!edges_);
   assert(!child_);
   edges_ = EdgeList({move});
   child_ = std::make_unique<Node>(this, 0);


### PR DESCRIPTION
Fixing wrong assert firing since NDEBUG was not defined.
    
    This occured whenever we tried to get backward into the move tree.
    It's fixed twice:
    . NDEBUG is now defined, silenting all asserts.
    . The culprit assert have been removed.